### PR TITLE
Cleaning up Docker image and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-# Version. Can change in build progress
-ARG GCLOUD_SDK_VERSION=alpine
+ARG GCLOUD_SDK_VERSION=271.0.0-alpine
 
-# Use google cloud sdk
 FROM google/cloud-sdk:$GCLOUD_SDK_VERSION
 
-# Install Java 8 for Datastore emulator
-RUN apk add --update --no-cache openjdk8-jre &&\
-    gcloud components install cloud-firestore-emulator beta --quiet
+RUN gcloud components install cloud-firestore-emulator beta --quiet
 
-# Volume to persist Datastore data
-VOLUME /opt/data
+COPY entrypoint.sh .
 
-COPY start-firestore .
+ENV PORT 8080
+EXPOSE "$PORT"
 
-EXPOSE 8080
-
-ENTRYPOINT ["./start-firestore"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GCLOUD_SDK_VERSION=271.0.0-alpine
 FROM google/cloud-sdk:$GCLOUD_SDK_VERSION
 LABEL maintainer="Michael Lynch <michael@mtlynch.io>"
 
-# Install Java 8 for Datastore emulator.
+# Install Java 8 JRE (required for  Firestore emulator).
 RUN apk add --update --no-cache openjdk8-jre
 
 # Install Firestore Emulator.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 ARG GCLOUD_SDK_VERSION=271.0.0-alpine
 
 FROM google/cloud-sdk:$GCLOUD_SDK_VERSION
+LABEL maintainer="Michael Lynch <michael@mtlynch.io>"
 
+# Install Java 8 for Datastore emulator.
+RUN apk add --update --no-cache openjdk8-jre
+
+# Install Firestore Emulator.
 RUN gcloud components install cloud-firestore-emulator beta --quiet
 
 COPY entrypoint.sh .
 
 ENV PORT 8080
 EXPOSE "$PORT"
+
+ENV FIRESTORE_PROJECT_ID "dummy-firestore-id"
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -2,98 +2,50 @@
 
 [![CircleCI](https://circleci.com/gh/mtlynch/firestore-emulator-docker.svg?style=svg)](https://circleci.com/gh/mtlynch/firestore-emulator-docker) [![Docker Pulls](https://img.shields.io/docker/pulls/mtlynch/firestore-emulator.svg?maxAge=604800)](https://hub.docker.com/r/mtlynch/firestore-emulator/) [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
 
-A [Google Cloud Firestore Emulator](https://cloud.google.com/sdk/gcloud/reference/beta/emulators/firestore/) container image. The image is meant to be used for creating an standalone emulator for testing.
+A [Google Cloud Firestore Emulator](https://cloud.google.com/sdk/gcloud/reference/beta/emulators/firestore/) container image. The image creates a local, standalone Firestore emulator for testing Firestore-backed apps.
 
 ## Quickstart
+
+To run the emulator in a standalone Docker container:
 
 ```bash
 docker run \
   --name firestore-emulator \
-  -v ${PWD}/firestore-data:/opt/data \
-  -e "FIRESTORE_PROJECT_ID=project-test" \
-  -p 8080:8080 \
-  -d \
+  --env "FIRESTORE_PROJECT_ID=dummy-project-id" \
+  --env "PORT=8080" \
+  --publish 8080:8080 \
   mtlynch/firestore-emulator-docker
 ```
 
-or with compose
+## Example docker-compose configuration
+
+To run the emulator in a `docker-compose` configuration with your app, use the following example configuration for reference.
 
 ```yaml
-version: "2"
-
+version: "3.2"
 services:
-  firestore-emulator:
+  firestore_emulator:
     image: mtlynch/cloud-firestore-emulator
-    volumes:
-      - firestore-data:/opt/data
     environment:
-      - FIRESTORE_PROJECT_ID=project-test
+      - FIRESTORE_PROJECT_ID=dummy-project-id
+      - PORT=8200
   app:
     image: your-app-image
     environment:
-      - FIRESTORE_EMULATOR_HOST=firestore
-      - FIRESTORE_PROJECT_ID=project-test
+      - FIRESTORE_EMULATOR_HOST=firestore_emulator:8200
+      - FIRESTORE_PROJECT_ID=dummy-project-id
+  depends_on:
+    - firestore_emulator
 ```
 
+## Environment variables
 
-## Environment
+* `FIRESTORE_PROJECT_ID`: This is the Google Cloud Project ID that the emulator uses.
+  * This does not have to correspond to a real Google Cloud Project ID, although it can if you want it to.
+  * Your application must set its firestore project ID value to match this environment variable.
 
-The following environment variables must be set:
+## Connecting to the emulator
 
-- `FIRESTORE_PROJECT_ID`: The ID of the Google Cloud project for the emulator.
+If you're using a standard Firestore client library and set the environment variable `FIRESTORE_EMULATOR_HOST`, then your app will connect to the emulator instead of the production Firestore URL. The variable specifies a host:port pair where the emulator is listening, for example `firestore_emulator:8080`.
 
-## Networking
-
-The emulator listens on port `8080`
-
-## Connect application with the emulator
-
-The following environment variables need to be set so your application connects to the emulator instead of the production Cloud Firestore environment:
-
-- `FIRESTORE_EMULATOR_HOST`: The listen address used by the emulator (ie. `firestore-emulator:8080`)
-- `FIRESTORE_PROJECT_ID`: The ID of the Google Cloud project used by the emulator.
-
-## Data persistance
-
-Data is saved in the `/opt/data` directory on the container.
-
-You can mount a volume on it.
-
-## Custom commands
-
-This image contains a script named `start-firestore` (included in the PATH). This script is used to initialize the Datastore emulator.
-
-### Starting an emulator
-
-By default, the following command is called:
-
-```bash
-start-firestore
-```
-
-### Starting an emulator with options
-
-This image comes with options. Check [Firestore Emulator GCloud Wide Flags](https://cloud.google.com/sdk/gcloud/reference/beta/emulators/firestore/). `--legacy`, `--data-dir` and `--host-port` are not supported by this image.
-
-## Creating a Firestore emulator with Docker Compose
-
-The easiest way to create an emulator with this image is by using [Docker Compose](https://docs.docker.com/compose). The following snippet can be used as a `docker-compose.yml` for a firestore emulator:
-
-```yaml
-version: "2"
-
-services:
-  firestore:
-    image: mtlynch/cloud-firestore-emulator
-    volumes:
-      - firestore-data:/opt/data
-    environment:
-      - FIRESTORE_PROJECT_ID=project-test
-  app:
-    image: your-app-image
-    environment:
-      - FIRESTORE_EMULATOR_HOST=firestore
-      - FIRESTORE_PROJECT_ID=project-test
-    depends_on:
-      - firestore
-```
+Your app must also set the `FIRESTORE_PROJECT_ID` or explicitly set a Firestore project ID to match the `FIRESTORE_PROJECT_ID` you set in the emulator. The image's default project ID is `dummy-firestore-id`.

--- a/build
+++ b/build
@@ -6,9 +6,28 @@ set -e
 set -x
 
 IMAGE_NAME="firestore-emulator"
+CONTAINER_NAME="firestore-emulator"
+PORT="8080"
+FIRESTORE_PROJECT_ID="dummy-project-id"
 
 docker version
+
+# Clear any previous container.
+docker rm -f "$CONTAINER_NAME" || true
 
 docker build \
   --tag "$IMAGE_NAME" \
   .
+
+docker run \
+  --name "$CONTAINER_NAME" \
+  --detach \
+  --env "FIRESTORE_PROJECT_ID=${FIRESTORE_PROJECT_ID}" \
+  --env "PORT=${PORT}" \
+  --publish "${PORT}:${PORT}" \
+  "$IMAGE_NAME"
+
+# Basic test to see if the emulator started.
+wget -qO- "http://localhost:${PORT}/v1/projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/dummy-document"
+
+docker rm -f "$CONTAINER_NAME"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,12 +2,6 @@
 
 set -xe
 
-# Check user environment variable
-if [[ -z "${FIRESTORE_PROJECT_ID}" ]]; then
-  echo "Missing FIRESTORE_PROJECT_ID environment variable" >&2
-  exit 1
-fi
-
 # Config gcloud project
 gcloud config set project "${FIRESTORE_PROJECT_ID}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+set -xe
 
 # Check user environment variable
 if [[ -z "${FIRESTORE_PROJECT_ID}" ]]; then
@@ -7,7 +9,8 @@ if [[ -z "${FIRESTORE_PROJECT_ID}" ]]; then
 fi
 
 # Config gcloud project
-gcloud config set project ${FIRESTORE_PROJECT_ID}
+gcloud config set project "${FIRESTORE_PROJECT_ID}"
 
 # Start emulator
-gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+gcloud beta emulators firestore start \
+  --host-port="0.0.0.0:${PORT}"


### PR DESCRIPTION
Getting rid of some artifacts from when it was a datastore emulator.
Simplifying the README.
Making the environment variables more explicit, but adding defaults.
Adding support for a configurable PORT option.