### PR TITLE
Fix image name on docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run the emulator in a `docker-compose` configuration with your app, use the f
 version: "3.2"
 services:
   firestore_emulator:
-    image: mtlynch/cloud-firestore-emulator
+    image: mtlynch/firestore-emulator
     environment:
       - FIRESTORE_PROJECT_ID=dummy-project-id
       - PORT=8200


### PR DESCRIPTION
I got an access denied error when trying to use this image. It turns out I copied your docker-compose example and the name of the image is wrong (it has the github name, not the docker hub name :D)

Thanks!