### PR TITLE
change: use latest alpine version for cloud-sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG GCLOUD_SDK_VERSION=335.0.0-alpine
-
-FROM google/cloud-sdk:$GCLOUD_SDK_VERSION
+FROM google/cloud-sdk:alpine
 LABEL maintainer="Michael Lynch <michael@mtlynch.io>"
 
 # Install Java 8 JRE (required for Firestore emulator).


### PR DESCRIPTION
Current version is pulling an old image of Firestore which does not support `!=` operator. Please consider using latest alpine version for `cloud-sdk`.

Please close this PR if this change is not acceptable, Thanks