### PR TITLE
properly expose port in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ services:
     environment:
       - FIRESTORE_PROJECT_ID=dummy-project-id
       - PORT=8200
+    ports:
+      - 8200:8200
   app:
     image: your-app-image
     environment:


### PR DESCRIPTION
I tested and docker-compose with a different port doesn't expose the proper port - it still exposes 8080.  So this is needed for the expected behavior.